### PR TITLE
Make nextupdatetime more reliable

### DIFF
--- a/bin/feedio
+++ b/bin/feedio
@@ -49,7 +49,7 @@ function read(FeedIo $feedIo, string $url)
 
     $updateStats = $result->getUpdateStats();
 
-    echo "\033[32mMinimum interval between items : \033[34m".formatDateInterval($updateStats->getMedianInterval())."\033[0m" . PHP_EOL;
+    echo "\033[32mMinimum interval between items : \033[34m".formatDateInterval($updateStats->getMinInterval())."\033[0m" . PHP_EOL;
     echo "\033[32mMedian interval : \033[34m".formatDateInterval($updateStats->getMedianInterval())."\033[0m" . PHP_EOL;
     echo "\033[32mAverage interval : \033[34m".formatDateInterval($updateStats->getAverageInterval())."\033[0m" . PHP_EOL;
     echo "\033[32mMaximum interval : \033[34m".formatDateInterval($updateStats->getMaxInterval())."\033[0m". PHP_EOL;

--- a/src/FeedIo/Reader/Result/UpdateStats.php
+++ b/src/FeedIo/Reader/Result/UpdateStats.php
@@ -42,7 +42,7 @@ class UpdateStats
     ) {
         $dates = $this->extractDates($feed);
         if (count($dates) > 0) {
-            $this->newestItemDate = max($dates);
+            $this->newestItemDate = min(max($dates), time());
         } else {
             $this->newestItemDate = $this->getFeedTimestamp();
         }

--- a/src/FeedIo/Reader/Result/UpdateStats.php
+++ b/src/FeedIo/Reader/Result/UpdateStats.php
@@ -125,7 +125,27 @@ class UpdateStats
      */
     public function getAverageInterval(): int
     {
-        $total = array_sum($this->intervals);
+        sort($this->intervals);
+
+        $count = count($this->intervals);
+        if ($count === 0) {
+            return 0;
+        }
+
+        // some feeds could have very old historic
+        // articles so eliminate them with statistic
+        $q1 = $this->intervals[floor($count * 0.25)];
+        $q3 = $this->intervals[floor($count * 0.75)];
+        $iqr = $q3 - $q1;
+
+        $lower_bound = $q1 - 1.5 * $iqr;
+        $upper_bound = $q3 + 1.5 * $iqr;
+
+        $result = array_filter($this->intervals, function($value) use ($lower_bound, $upper_bound) {
+            return $value >= $lower_bound && $value <= $upper_bound;
+        });
+
+        $total = array_sum($result);
 
         return count($this->intervals) ? intval(floor($total / count($this->intervals))) : 0;
     }

--- a/src/FeedIo/Reader/Result/UpdateStats.php
+++ b/src/FeedIo/Reader/Result/UpdateStats.php
@@ -156,9 +156,19 @@ class UpdateStats
     public function getMedianInterval(): int
     {
         sort($this->intervals);
-        $num = floor(count($this->intervals) / 2);
 
-        return isset($this->intervals[$num]) ? $this->intervals[$num] : 0;
+        $count = count($this->intervals);
+        if ($count === 0) {
+            return 0;
+        }
+
+        $num = floor($count / 2);
+
+        if ($count % 2 === 0) {
+            return intval(floor(($this->intervals[$num - 1] + $this->intervals[$num]) / 2));
+        } else {
+            return $this->intervals[$num];
+        }
     }
 
     private function computeIntervals(array $dates): array

--- a/src/FeedIo/Reader/Result/UpdateStats.php
+++ b/src/FeedIo/Reader/Result/UpdateStats.php
@@ -31,6 +31,8 @@ class UpdateStats
 
     protected array $intervals = [];
 
+    protected int $newestItemDate = 0;
+
     /**
      * UpdateStats constructor.
      * @param FeedInterface $feed
@@ -38,7 +40,13 @@ class UpdateStats
     public function __construct(
         protected FeedInterface $feed
     ) {
-        $this->intervals = $this->computeIntervals($this->extractDates($feed));
+        $dates = $this->extractDates($feed);
+        if (count($dates) > 0) {
+            $this->newestItemDate = max($dates);
+        } else {
+            $this->newestItemDate = $this->getFeedTimestamp();
+        }
+        $this->intervals = $this->computeIntervals($dates);
     }
 
     /**
@@ -57,7 +65,6 @@ class UpdateStats
         if ($this->isSleepy($sleepyDuration, $marginRatio)) {
             return (new \DateTime())->setTimestamp(time() + $sleepyDelay);
         }
-        $feedTimeStamp = $this->getFeedTimestamp();
         $now = time();
         $intervals = [
             $this->getAverageInterval(),
@@ -66,7 +73,7 @@ class UpdateStats
         sort($intervals);
         $newTimestamp = $now + $minDelay;
         foreach ($intervals as $interval) {
-            $computedTimestamp = $this->addInterval($feedTimeStamp, $interval, $marginRatio);
+            $computedTimestamp = $this->addInterval($this->newestItemDate, $interval, $marginRatio);
             if ($computedTimestamp > $now) {
                 $newTimestamp = $computedTimestamp;
                 break;
@@ -82,7 +89,7 @@ class UpdateStats
      */
     public function isSleepy(int $sleepyDuration, float $marginRatio): bool
     {
-        return time() > $this->addInterval($this->getFeedTimestamp(), $sleepyDuration, $marginRatio);
+        return time() > $this->addInterval($this->newestItemDate, $sleepyDuration, $marginRatio);
     }
 
     /**
@@ -169,6 +176,14 @@ class UpdateStats
         } else {
             return $this->intervals[$num];
         }
+    }
+
+    /**
+     * @return int
+     */
+    public function getNewestItemDate(): int
+    {
+        return $this->newestItemDate;
     }
 
     private function computeIntervals(array $dates): array

--- a/tests/FeedIo/Reader/Result/UpdateStatsTest.php
+++ b/tests/FeedIo/Reader/Result/UpdateStatsTest.php
@@ -35,7 +35,9 @@ class UpdateStatsTest extends TestCase
         $this->assertEquals(86400, $stats->getMinInterval());
         $nextUpdate = $stats->computeNextUpdate();
         $averageInterval = $stats->getAverageInterval();
-        $this->assertEquals($feed->getLastModified()->getTimestamp() + intval($averageInterval + 0.1 * $averageInterval), $nextUpdate->getTimestamp());
+        $medianInterval = $stats->getMedianInterval();
+        $computedInterval = ($medianInterval < $averageInterval ? $medianInterval : $averageInterval);
+        $this->assertEquals($stats->getNewestItemDate() + intval($computedInterval + 0.1 * $computedInterval), $nextUpdate->getTimestamp());
     }
 
     public function testSleepyFeed()


### PR DESCRIPTION
Imported: https://github.com/alexdebril/feed-io/pull/434

Feeds may, for whatever reason, contain older articles, which disproportionately shifts the nextUpdateTime based on the average. This happens when the last update time + median does not yield a date in the future, and then the average is taken.

For example you have a feed with 20 items, where 15 items are from the last 2 hours and 5 are month ago. The median will than very low compared to the average. To prevent this, outliers are removed using the interquartile range.

Another problem are feeds that are generated during download and therefore the last modified time corresponds to the download. These feeds are not recognized as sleepy and are therefore calculated incorrectly.
It is therefore better to use the time of the most recent article as the basis.

Here are two examples for the first problem:

This feed is very active during the day, has 20 items that were mostly written in the last 1.5-2 hours. Towards the evening the intervals increases and from time to time there are items that are months old. It can therefore happen that the next update time is postponed by a week.

bin/feedio read https://newsfeed.kicker.de/news/aktuell

[kicker.xml.txt](https://github.com/user-attachments/files/18481730/kicker.xml.txt)

Currently:

    Next time a new item may be published : 2025-01-27T02:45:31+00:00
    Minimum interval between items : 0 days, 0 hours, 5 minutes, 57 seconds
    Median interval : 0 days, 0 hours, 5 minutes, 57 seconds
    Average interval : 8 days, 11 hours, 46 minutes, 8 seconds
    Maximum interval : 161 days, 5 hours, 21 minutes, 7 seconds

Patched version:

    Next time a new item may be published : 2025-01-20T20:09:18+00:00
    Minimum interval between items : 0 days, 0 hours, 0 minutes, 4 seconds
    Median interval : 0 days, 0 hours, 5 minutes, 57 seconds
    Average interval : 0 days, 0 hours, 7 minutes, 8 seconds
    Maximum interval : 161 days, 5 hours, 21 minutes, 7 seconds

Same for this feed, here there are always old items.

[sportschau.xml.txt](https://github.com/user-attachments/files/18481733/sportschau.xml.txt)

bin/feedio read "https://www.sportschau.de/fussball/index~rss2.xml"

Currently:

    Next time a new item may be published : 2025-01-22T19:45:04+00:00
    Minimum interval between items : 0 days, 0 hours, 55 minutes, 53 seconds
    Median interval : 0 days, 0 hours, 55 minutes, 53 seconds
    Average interval : 2 days, 16 hours, 49 minutes, 14 seconds
    Maximum interval : 48 days, 2 hours, 46 minutes, 50 seconds

Patched version:

    Next time a new item may be published : 2025-01-20T20:13:59+00:00
    Minimum interval between items : 0 days, 0 hours, 1 minutes, 28 seconds
    Median interval : 0 days, 0 hours, 55 minutes, 53 seconds
    Average interval : 0 days, 2 hours, 22 minutes, 10 seconds
    Maximum interval : 48 days, 2 hours, 46 minutes, 50 seconds