### PR TITLE
Change: do no longer default to 1800-01-01 as date for fetching feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Add logic to set the node's link from the <guid> element when isPermaLink="true" and no link is present. (#12)
+- Do no longer default to 1800-01-01 as date for fetching feeds (#15)
 
 ### Fixed
-- Fix: Analysis of relative links for the Atom feed (#13)
+- Analysis of relative links for the Atom feed (#10)

--- a/src/FeedIo/Reader.php
+++ b/src/FeedIo/Reader.php
@@ -66,9 +66,6 @@ class Reader
     public function read(string $url, FeedInterface $feed, DateTime $modifiedSince = null): Result
     {
         $this->logger->debug("start reading {$url}");
-        if (is_null($modifiedSince)) {
-            $modifiedSince = new DateTime('1800-01-01');
-        }
 
         try {
             $this->logger->info("hitting {$url}");

--- a/src/FeedIo/Reader/Result.php
+++ b/src/FeedIo/Reader/Result.php
@@ -32,7 +32,7 @@ class Result
     public function __construct(
         protected Document $document,
         protected FeedInterface $feed,
-        protected DateTime $modifiedSince,
+        protected ?DateTime $modifiedSince = null,
         protected ResponseInterface $response,
         protected string $url
     ) {
@@ -56,8 +56,15 @@ class Result
 
     public function getItemsSince(DateTime $since = null): iterable
     {
+        $startDate = $since ?? $this->modifiedSince;
+
+        // return all items if no start date is given
+        if ($startDate === null) {
+            return $this->feed;
+        }
+        
         $filter = new Chain();
-        $filter->add(new Since($since ?? $this->modifiedSince));
+        $filter->add(new Since($startDate));
 
         return $filter->filter($this->getFeed());
     }

--- a/tests/FeedIo/ReaderTest.php
+++ b/tests/FeedIo/ReaderTest.php
@@ -131,7 +131,7 @@ class ReaderTest extends TestCase
         $feed = new Feed();
         $this->object->addParser($this->getParser());
         $result = $this->object->read('fakeurl', $feed);
-        $this->assertEquals(new \DateTime('1800-01-01'), $result->getModifiedSince());
+        $this->assertEquals(null, $result->getModifiedSince());
     }
 
     public function testReadException()


### PR DESCRIPTION
Following the case from [alexdebril/feed-io#415](https://github.com/alexdebril/feed-io/issues/415), the current method-signature of `Reader->read()` invalidates `Adapter/Http/Client->getResponse()` by defining a value for `$modifiedSince` other than its default, `null`.

When querying a feed that does not support HEAD-requests, it will fail. This is the current case for BlueSky. Eg., a GET-request `-- curl https://bsky.app/profile/did:plc:eclio37ymobqex2ncko63h4r/rss` works fine, adding `--head` gives 404-response. This should of course be a 405-response.

This is the case for both the [5](https://github.com/php-feed-io/feed-io/blob/v5.3.3/src/FeedIo/Reader.php#L66)- and [6](https://github.com/php-feed-io/feed-io/blob/v6.0.3/src/FeedIo/Reader.php#L66)-major version range: When calling [getResponse()](https://github.com/php-feed-io/feed-io/blob/main/src/FeedIo/Adapter/Http/Client.php#L28), the fallback GET-request is not reached if the prior requests throws an error.