### PR TITLE
Release v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+### Fixed
+
+## [v6.1.0] - 2025-08-13
+### Changed
 - Add logic to set the node's link from the <guid> element when isPermaLink="true" and no link is present. (#12)
 - Do no longer default to 1800-01-01 as date for fetching feeds (#15)
-- don't set if-modified-since header when discover feeds (#19)
+- Don't set if-modified-since header when discover feeds (#19)
 
 ### Fixed
 - Analysis of relative links for the Atom feed (#10)
+- Implicit null deprecations fixed (#17)


### PR DESCRIPTION
Changed
- Add logic to set the node's link from the <guid> element when isPermaLink="true" and no link is present. (#12)
- Do no longer default to 1800-01-01 as date for fetching feeds (#15)
- Don't set if-modified-since header when discover feeds (#19)

Fixed
- Analysis of relative links for the Atom feed (#10)
- Implicit null deprecations fixed (#17)