### PR TITLE
fix: rewrite relative links in `content:encoded` and other optional e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- fix: rewrite relative links in `content:encoded` and other optional elements, not only in `content`/`description` properties
 
 ## Released
 ## [v6.4.1] - 2026-07-19

--- a/src/FeedIo/Feed/Node.php
+++ b/src/FeedIo/Feed/Node.php
@@ -193,6 +193,23 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
         $this->pregReplaceInProperty('content', $pattern, '\1\2\3'.$itemLink.'\4');
         $this->pregReplaceInProperty('description', $pattern, '\1\2\3'.$itemLink.'\4');
 
+        // Apply the same rewriting to elements that contain HTML (e.g. content:encoded).
+        // Step 3 (resolveRelativePathLinksInContent) already ran for elements above;
+        // here we handle the remaining root-relative, fragment, and bare-word patterns.
+        $rootPattern = '~(<\s*[^>]*)(href=|src=)(.?)(\/[^\/])(?!(.(?!<code))*<\/code>)~';
+        $hashPattern = '~(<\s*[^>]*)(href=|src=)(.?)(#)(?!(.(?!<code))*<\/code>)~';
+        $wordPattern = '~(<\s*[^>]*)(href=|src=)(.?)(\w+\b)(?![:])(?!(.(?!<code))*<\/code>)~';
+        foreach ($this->getAllElements() as $element) {
+            $value = $element->getValue();
+            if ($value === null || (!str_contains($value, 'href=') && !str_contains($value, 'src='))) {
+                continue;
+            }
+            $value = preg_replace($rootPattern, '\1\2\3'.$host.'\4', $value) ?? $value;
+            $value = preg_replace($hashPattern, '\1\2\3'.$itemFullLink.'\4', $value) ?? $value;
+            $value = preg_replace($wordPattern, '\1\2\3'.$itemLink.'\4', $value) ?? $value;
+            $element->setValue($value);
+        }
+
         return $this;
     }
 
@@ -265,18 +282,22 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
         foreach (['content', 'description'] as $property) {
             $this->replaceRelativeLinksInProperty($property, $resolver);
         }
+
+        // Also resolve relative links in elements that contain HTML (e.g. content:encoded).
+        foreach ($this->getAllElements() as $element) {
+            $value = $element->getValue();
+            if ($value !== null && (str_contains($value, 'href=') || str_contains($value, 'src='))) {
+                $element->setValue($this->applyResolverToHtml($value, $resolver));
+            }
+        }
     }
 
-    private function replaceRelativeLinksInProperty(string $property, callable $resolver): void
+    private function applyResolverToHtml(string $html, callable $resolver): string
     {
-        if (!property_exists($this, $property) || is_null($this->{$property})) {
-            return;
-        }
-
         $pattern = '~((?:href|src)=)(["\'])([^"\'<>\s]+)\2~i';
-        $segments = preg_split('/(<\/?code>)/i', $this->{$property}, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $segments = preg_split('/(<\/?code>)/i', $html, -1, PREG_SPLIT_DELIM_CAPTURE);
         if ($segments === false) {
-            return;
+            return $html;
         }
 
         $result = '';
@@ -296,7 +317,16 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
             $result .= preg_replace_callback($pattern, $resolver, $segment) ?? $segment;
         }
 
-        $this->{$property} = $result;
+        return $result;
+    }
+
+    private function replaceRelativeLinksInProperty(string $property, callable $resolver): void
+    {
+        if (!property_exists($this, $property) || is_null($this->{$property})) {
+            return;
+        }
+
+        $this->{$property} = $this->applyResolverToHtml($this->{$property}, $resolver);
     }
 
     public function pregReplaceInProperty(string $property, string $pattern, string $replacement): void

--- a/tests/FeedIo/Feed/NodeTest.php
+++ b/tests/FeedIo/Feed/NodeTest.php
@@ -231,4 +231,45 @@ class NodeTest extends TestCase
             $item->getContent()
         );
     }
+
+    public function testSetHostInContentRewritesRootRelativeLinksInElements(): void
+    {
+        $item = new Item();
+        $item->setLink('https://jmduke.com/posts/adaptation.html');
+
+        $element = $item->newElement();
+        $element->setName('content:encoded');
+        $element->setValue('<p>See <a href="/posts/being-john-malkovich.html">BJM</a> and <a href="https://external.com">external</a></p>');
+        $item->addElement($element);
+
+        $item->setHostInContent('https://jmduke.com');
+
+        $stored = null;
+        foreach ($item->getElementIterator('content:encoded') as $el) {
+            $stored = $el->getValue();
+        }
+
+        $this->assertStringContainsString('href="https://jmduke.com/posts/being-john-malkovich.html"', $stored);
+        $this->assertStringContainsString('href="https://external.com"', $stored);
+    }
+
+    public function testSetHostInContentRewritesRelativePathLinksInElements(): void
+    {
+        $item = new Item();
+        $item->setLink('https://example.com/posts/page.html');
+
+        $element = $item->newElement();
+        $element->setName('content:encoded');
+        $element->setValue('<a href="../other.html">Other</a>');
+        $item->addElement($element);
+
+        $item->setHostInContent('https://example.com');
+
+        $stored = null;
+        foreach ($item->getElementIterator('content:encoded') as $el) {
+            $stored = $el->getValue();
+        }
+
+        $this->assertStringContainsString('href="https://example.com/other.html"', $stored);
+    }
 }


### PR DESCRIPTION
This pull request improves how relative links are rewritten in feed items, ensuring that not only the main `content` and `description` fields but also additional HTML-containing elements (such as `content:encoded`) have their links properly resolved. This makes the link rewriting logic more robust and comprehensive. The changes also add new tests to verify this behavior.

**Improvements to relative link rewriting:**

* Updated `setHostInContent` in `Node.php` to rewrite relative links in all HTML-containing elements (like `content:encoded`), not just in `content` and `description` properties. [[1]](diffhunk://#diff-bfb7fbb317d600d1322e2cb257d82f5fa4e05929a68b1ff4897f9fa89af85da6R196-R212) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13)
* Refactored the logic for resolving relative links by introducing `applyResolverToHtml`, which processes HTML content for both properties and elements, and updated `replaceRelativeLinksInProperty` to use this shared logic. [[1]](diffhunk://#diff-bfb7fbb317d600d1322e2cb257d82f5fa4e05929a68b1ff4897f9fa89af85da6L268-R300) [[2]](diffhunk://#diff-bfb7fbb317d600d1322e2cb257d82f5fa4e05929a68b1ff4897f9fa89af85da6L299-R329)

**Test coverage:**

* Added tests in `NodeTest.php` to verify that root-relative and relative path links in elements (such as `content:encoded`) are correctly rewritten to absolute URLs.

These changes ensure more consistent and reliable link rewriting across all relevant feed item fields.